### PR TITLE
feat: Add inventory on the Travel page

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -39,3 +39,6 @@ next-env.d.ts
 /public/sw.js
 /public/sw.js.map
 /public/workbox-*
+
+# editor configuration
+.vscode

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -99,21 +99,6 @@ const Header = ({ back }: HeaderProps) => {
                 <HStack>
                   <Heart /> <Text>{playerEntity.health}</Text>
                 </HStack>
-                <Divider
-                  orientation="vertical"
-                  borderColor="neon.600"
-                  h="12px"
-                />
-                <HStack>
-                  <Siren />
-                  <Text>
-                    {getInventoryCapacityPercentage(
-                      playerEntity?.drugCount,
-                      playerEntity?.bagLimit,
-                    )}
-                    %
-                  </Text>
-                </HStack>
                 {/* <Divider
                   orientation="vertical"
                   borderColor="neon.600"

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Clock, Gem, Bag, Arrow, Heart, Siren } from "./icons";
+import { Clock, Gem, Bag, Arrow, Heart, Siren, Dots } from "./icons";
 import { Button, Divider, Flex, HStack, Text } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { IsMobile, generatePixelBorderPath } from "@/utils/ui";
@@ -7,7 +7,7 @@ import { initSoundStore } from "@/hooks/sound";
 import HeaderButton from "@/components/HeaderButton";
 import MediaPlayer from "@/components/MediaPlayer";
 import MobileMenu from "@/components/MobileMenu";
-import { usePlayerEntity } from "@/dojo/entities/usePlayerEntity";
+import { usePlayerEntity, PlayerEntity } from "@/dojo/entities/usePlayerEntity";
 import { useGameEntity } from "@/dojo/entities/useGameEntity";
 import { formatCash } from "@/utils/ui";
 import { useDojo } from "@/dojo";
@@ -21,6 +21,13 @@ const MAX_INVENTORY = 100;
 
 export interface HeaderProps {
   back?: boolean;
+}
+
+function getInventoryCapacityPercentage(playerEntity?: PlayerEntity): number {
+  if (!playerEntity || playerEntity.drugCount === 0) {
+    return 0;
+  }
+  return Math.ceil((playerEntity.drugCount / playerEntity.bagLimit) * 100);
 }
 
 const Header = ({ back }: HeaderProps) => {
@@ -65,8 +72,7 @@ const Header = ({ back }: HeaderProps) => {
       align="flex-start"
       py={["0", "20px"]}
     >
-      <HStack flex="1" justify={["left", "right"]}>
-      </HStack>
+      <HStack flex="1" justify={["left", "right"]}></HStack>
       {playerEntity && gameEntity && (
         <HStack flex="1" justify="center">
           <HStack
@@ -75,7 +81,7 @@ const Header = ({ back }: HeaderProps) => {
             px="20px"
             spacing={["10px", "30px"]}
             bg="neon.700"
-            sx={{...headerStyles}}
+            sx={{ ...headerStyles }}
           >
             <Flex w="full" align="center" justify="center" gap="10px">
               <HStack>
@@ -89,6 +95,15 @@ const Header = ({ back }: HeaderProps) => {
                 />
                 <HStack>
                   <Heart /> <Text>{playerEntity.health}</Text>
+                </HStack>
+                <Divider
+                  orientation="vertical"
+                  borderColor="neon.600"
+                  h="12px"
+                />
+                <HStack>
+                  <Siren />
+                  <Text>{getInventoryCapacityPercentage(playerEntity)}%</Text>
                 </HStack>
                 {/* <Divider
                   orientation="vertical"
@@ -104,7 +119,7 @@ const Header = ({ back }: HeaderProps) => {
         </HStack>
       )}
 
-      <HStack flex="1" justify="right" >
+      <HStack flex="1" justify="right">
         {!isMobile && (
           <>
             <MediaPlayer />

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -7,7 +7,7 @@ import { initSoundStore } from "@/hooks/sound";
 import HeaderButton from "@/components/HeaderButton";
 import MediaPlayer from "@/components/MediaPlayer";
 import MobileMenu from "@/components/MobileMenu";
-import { usePlayerEntity, PlayerEntity } from "@/dojo/entities/usePlayerEntity";
+import { usePlayerEntity } from "@/dojo/entities/usePlayerEntity";
 import { useGameEntity } from "@/dojo/entities/useGameEntity";
 import { formatCash } from "@/utils/ui";
 import { useDojo } from "@/dojo";

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -23,11 +23,14 @@ export interface HeaderProps {
   back?: boolean;
 }
 
-function getInventoryCapacityPercentage(playerEntity?: PlayerEntity): number {
-  if (!playerEntity || playerEntity.drugCount === 0) {
+function getInventoryCapacityPercentage(
+  drugCount?: number,
+  bagLimit?: number,
+): number {
+  if (!drugCount || !bagLimit || drugCount === 0) {
     return 0;
   }
-  return Math.ceil((playerEntity.drugCount / playerEntity.bagLimit) * 100);
+  return Math.floor((drugCount / bagLimit) * 100);
 }
 
 const Header = ({ back }: HeaderProps) => {
@@ -103,7 +106,13 @@ const Header = ({ back }: HeaderProps) => {
                 />
                 <HStack>
                   <Siren />
-                  <Text>{getInventoryCapacityPercentage(playerEntity)}%</Text>
+                  <Text>
+                    {getInventoryCapacityPercentage(
+                      playerEntity?.drugCount,
+                      playerEntity?.bagLimit,
+                    )}
+                    %
+                  </Text>
                 </HStack>
                 {/* <Divider
                   orientation="vertical"

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -23,16 +23,6 @@ export interface HeaderProps {
   back?: boolean;
 }
 
-function getInventoryCapacityPercentage(
-  drugCount?: number,
-  bagLimit?: number,
-): number {
-  if (!drugCount || !bagLimit || drugCount === 0) {
-    return 0;
-  }
-  return Math.floor((drugCount / bagLimit) * 100);
-}
-
 const Header = ({ back }: HeaderProps) => {
   const router = useRouter();
   const { gameId } = router.query as { gameId: string };

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Clock, Gem, Bag, Arrow, Heart, Siren, Dots } from "./icons";
+import { Clock, Gem, Bag, Arrow, Heart, Siren } from "./icons";
 import { Button, Divider, Flex, HStack, Text } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { IsMobile, generatePixelBorderPath } from "@/utils/ui";

--- a/web/src/components/Inventory.tsx
+++ b/web/src/components/Inventory.tsx
@@ -28,7 +28,7 @@ export const Inventory = ({ ...props }: StyleProps) => {
   });
 
   return (
-    <VStack {...props} w="full" align="flex-start">
+    <VStack {...props} w="full" align="flex-start" pb="5px">
       <HStack w="full" justify="space-between">
         <Text
           textStyle="subheading"

--- a/web/src/components/Inventory.tsx
+++ b/web/src/components/Inventory.tsx
@@ -8,6 +8,9 @@ import {
   Spacer,
 } from "@chakra-ui/react";
 
+import BorderImage from "@/components/icons/BorderImage";
+import colors from "@/theme/colors";
+
 import React from "react";
 import { usePlayerEntity } from "@/dojo/entities/usePlayerEntity";
 import { useRouter } from "next/router";
@@ -49,6 +52,9 @@ export const Inventory = ({ ...props }: StyleProps) => {
         px="20px"
         justify="center"
         sx={{
+          borderImageSource: `url("data:image/svg+xml,${BorderImage({
+            color: colors.neon["700"].toString(),
+          })}")`,
           overflowY: "scroll",
           "&::-webkit-scrollbar": {
             display: "none",

--- a/web/src/components/Inventory.tsx
+++ b/web/src/components/Inventory.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   VStack,
   Card,
+  Spacer,
 } from "@chakra-ui/react";
 
 import React from "react";
@@ -26,10 +27,16 @@ export const Inventory = ({ ...props }: StyleProps) => {
   return (
     <VStack {...props} w="full" align="flex-start">
       <HStack w="full" justify="space-between">
-        <Text textStyle="subheading" fontSize="10px" color="neon.500">
+        <Text
+          textStyle="subheading"
+          fontSize="10px"
+          display={["none", "flex"]}
+          color="neon.500"
+        >
           Your Inventory
         </Text>
-        <HStack color="yellow.400">
+        <Spacer />
+        <HStack display={["none", "flex"]} color="yellow.400">
           <Bag />
           <Text>
             {playerEntity?.drugCount}/{playerEntity?.bagLimit}

--- a/web/src/dojo/entities/usePlayerEntity.tsx
+++ b/web/src/dojo/entities/usePlayerEntity.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { REFETCH_INTERVAL, SCALING_FACTOR } from "..";
 import { PlayerStatus } from "../types";
 
-type Drug = {
+export type Drug = {
   id: string;
   quantity: number;
 };

--- a/web/src/dojo/entities/usePlayerEntity.tsx
+++ b/web/src/dojo/entities/usePlayerEntity.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { REFETCH_INTERVAL, SCALING_FACTOR } from "..";
 import { PlayerStatus } from "../types";
 
-export type Drug = {
+type Drug = {
   id: string;
   quantity: number;
 };

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -299,7 +299,7 @@ const LocationInventory = ({
   drugs: Drug[];
   drugCount: number;
   bagLimit: number;
-  forMobile: boolean;
+  forMobile?: boolean;
 }) => {
   return (
     <VStack w="full" align="flex-start" mb="2">
@@ -359,48 +359,6 @@ const LocationInventory = ({
               })
             )}
           </HStack>
-        </Card>
-        <Card
-          flex="0.5"
-          cursor={"pointer"}
-          borderColor="gray.200"
-          bg={forMobile ? "neon.700" : ""}
-          w="12"
-          h="40px"
-          px="20px"
-          color="neon.500"
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          sx={{
-            overflowY: "scroll",
-            "&::-webkit-scrollbar": {
-              display: "none",
-            },
-          }}
-        >
-          <Truck color="yellow.400" />
-        </Card>
-        <Card
-          flex="0.5"
-          borderColor="gray.200"
-          cursor={"pointer"}
-          bg={forMobile ? "neon.700" : ""}
-          w="12"
-          h="40px"
-          px="20px"
-          color="neon.500"
-          display="flex"
-          alignItems="center"
-          justifyContent="center"
-          sx={{
-            overflowY: "scroll",
-            "&::-webkit-scrollbar": {
-              display: "none",
-            },
-          }}
-        >
-          <Pistol color="yellow.400" />
         </Card>
       </HStack>
     </VStack>

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -1,9 +1,9 @@
-import { Arrow, Car, Siren, Truck, Bag } from "@/components/icons";
+import { Arrow, Car, Siren, Truck } from "@/components/icons";
 import Layout from "@/components/Layout";
 import Button from "@/components/Button";
+import { Inventory } from "@/components/Inventory";
 import {
   Box,
-  Divider,
   HStack,
   VStack,
   Text,
@@ -26,7 +26,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { formatCash, generatePixelBorderPath } from "@/utils/ui";
 import { Map } from "@/components/map";
 import { useSystems } from "@/dojo/systems/useSystems";
-import { usePlayerEntity, Drug } from "@/dojo/entities/usePlayerEntity";
+import { usePlayerEntity } from "@/dojo/entities/usePlayerEntity";
 import { useToast } from "@/hooks/toast";
 import { useDojo } from "@/dojo";
 import { useMarketPrices } from "@/dojo/components/useMarkets";
@@ -193,14 +193,8 @@ export default function Travel() {
     >
       <VStack w="full" my="auto" display={["none", "flex"]} gap="20px">
         <VStack w="full" align="flex-start">
-          <LocationInventory
-            drugs={playerEntity.drugs}
-            drugCount={playerEntity.drugCount}
-            bagLimit={playerEntity.bagLimit}
-            forMobile={false}
-          />
-
-          <Text textStyle="subheading" fontSize="11px" color="neon.500">
+          <Inventory />
+          <Text pt={["0px", "20px"]} textStyle="subheading" fontSize="11px" color="neon.500">
             Location
           </Text>
           <LocationSelectBar
@@ -243,12 +237,7 @@ export default function Travel() {
         background="linear-gradient(transparent, 20%, #172217, 50%, #172217)"
         gap="14px"
       >
-        <LocationInventory
-          drugs={playerEntity.drugs}
-          drugCount={playerEntity.drugCount}
-          bagLimit={playerEntity.bagLimit}
-          forMobile={true}
-        />
+        <Inventory />
         <LocationSelectBar
           name={locationName}
           onNext={onNext}
@@ -281,81 +270,6 @@ export default function Travel() {
     </Layout>
   );
 }
-
-const LocationInventory = ({
-  drugs,
-  drugCount,
-  bagLimit,
-  forMobile = false,
-}: {
-  drugs: Drug[];
-  drugCount: number;
-  bagLimit: number;
-  forMobile?: boolean;
-}) => {
-  return (
-    <VStack w="full" align="flex-start" mb="2">
-      {!forMobile && (
-        <HStack w="full" justify="space-between">
-          <Text textStyle="subheading" fontSize="10px" color="neon.500">
-            Inventory
-          </Text>
-          <HStack color="yellow.400">
-            <Bag />
-            <Text>
-              {drugCount}/{bagLimit}
-            </Text>
-          </HStack>
-        </HStack>
-      )}
-      <HStack w="full" spacing={2}>
-        <Card
-          flex="15"
-          bg={forMobile ? "neon.700" : ""}
-          borderColor="gray.200"
-          w="full"
-          h="40px"
-          px="20px"
-          justify="center"
-          sx={{
-            overflowY: "scroll",
-            "&::-webkit-scrollbar": {
-              display: "none",
-            },
-          }}
-        >
-          <HStack gap="5px" justify="center">
-            {drugCount === 0 ? (
-              <Text color="neon.500">Your bag is empty</Text>
-            ) : (
-              drugs?.map((drug) => {
-                return (
-                  drug.quantity > 0 && (
-                    <>
-                      <HStack gap="10px">
-                        <HStack color="yellow.400">
-                          {getDrugById(drug.id)?.icon({ boxSize: "26" })}
-                          <Text>{drug.quantity}</Text>
-                        </HStack>
-                      </HStack>
-                      <Divider
-                        _last={{ display: "none" }}
-                        h="10px"
-                        orientation="vertical"
-                        borderWidth="1px"
-                        borderColor="neon.600"
-                      />
-                    </>
-                  )
-                );
-              })
-            )}
-          </HStack>
-        </Card>
-      </HStack>
-    </VStack>
-  );
-};
 
 const LocationPrices = ({
   prices,

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -239,7 +239,7 @@ export default function Travel() {
         spacing="0"
         pointerEvents="none"
         justify="flex-end"
-        background="linear-gradient(transparent, 20%, #172217, 50%, #172217)"
+        background="linear-gradient(transparent, 3.5%, #172217, 14%, #172217)"
         gap="14px"
       >
         <Inventory />

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -244,7 +244,7 @@ export default function Travel() {
         background="linear-gradient(transparent, 10%, #172217, 25%, #172217)"
         gap="14px"
       >
-        <Inventory pb="5px" />
+        <Inventory />
         <LocationSelectBar
           name={locationName}
           onNext={onNext}

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -194,7 +194,12 @@ export default function Travel() {
       <VStack w="full" my="auto" display={["none", "flex"]} gap="20px">
         <VStack w="full" align="flex-start">
           <Inventory />
-          <Text pt={["0px", "20px"]} textStyle="subheading" fontSize="11px" color="neon.500">
+          <Text
+            textStyle="subheading"
+            pt={["0px", "20px"]}
+            fontSize="11px"
+            color="neon.500"
+          >
             Location
           </Text>
           <LocationSelectBar

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -2,6 +2,8 @@ import { Arrow, Car, Siren, Truck } from "@/components/icons";
 import Layout from "@/components/Layout";
 import Button from "@/components/Button";
 import { Inventory } from "@/components/Inventory";
+import colors from "@/theme/colors";
+import BorderImage from "@/components/icons/BorderImage";
 import {
   Box,
   HStack,
@@ -232,17 +234,17 @@ export default function Travel() {
         display={["flex", "none"]}
         w="full"
         h="auto"
-        p="24px"
+        p="60px 24px 24px 24px"
         position="fixed"
         bottom="0"
         right="0"
         spacing="0"
         pointerEvents="none"
         justify="flex-end"
-        background="linear-gradient(transparent, 3.5%, #172217, 14%, #172217)"
+        background="linear-gradient(transparent, 10%, #172217, 25%, #172217)"
         gap="14px"
       >
-        <Inventory />
+        <Inventory pb="5px" />
         <LocationSelectBar
           name={locationName}
           onNext={onNext}
@@ -308,7 +310,16 @@ const LocationPrices = ({
           ({!isPercentage ? "#" : "%"})
         </Text>
       </HStack>
-      <Card w="full" p="5px" pointerEvents="all">
+      <Card
+        w="full"
+        p="5px"
+        pointerEvents="all"
+        sx={{
+          borderImageSource: `url("data:image/svg+xml,${BorderImage({
+            color: colors.neon["700"].toString(),
+          })}")`,
+        }}
+      >
         <Grid templateColumns="repeat(2, 1fr)" position="relative">
           <Box
             position="absolute"
@@ -323,7 +334,7 @@ const LocationPrices = ({
                 colSpan={1}
                 border="1px"
                 p="6px"
-                borderColor="neon.600"
+                borderColor="neon.700"
               >
                 <HStack gap="8px">
                   {getDrugById(drug.id)?.icon({

--- a/web/src/pages/[gameId]/travel.tsx
+++ b/web/src/pages/[gameId]/travel.tsx
@@ -1,12 +1,4 @@
-import {
-  Arrow,
-  Car,
-  Siren,
-  Truck,
-  Bag,
-  Pistol,
-  Sparkles,
-} from "@/components/icons";
+import { Arrow, Car, Siren, Truck, Bag } from "@/components/icons";
 import Layout from "@/components/Layout";
 import Button from "@/components/Button";
 import {


### PR DESCRIPTION
Issue [#198](https://github.com/cartridge-gg/rollyourown/issues/198)

**Added**:
* Inventory capacity in the header
* Inventory list on the Travel page

**Comments**:

For the inventory of the mobile version, I added a little background cause inventory items were difficult to see when overlapping with the map. Let me know if I should change it!

------

Empty inventory:

![Empty inventory](https://i.imgur.com/BLw0vS4.png)

Not empty:

![Not empty](https://i.imgur.com/n1GEuvP.png)

Not empty (mobile):

![Not empty on mobile](https://i.imgur.com/pH5UmGY.png)